### PR TITLE
Add event extraction

### DIFF
--- a/migrations/versions/854c7f4bb0c1_add_event_table.py
+++ b/migrations/versions/854c7f4bb0c1_add_event_table.py
@@ -1,0 +1,33 @@
+"""add events table
+
+Revision ID: 854c7f4bb0c1
+Revises: f26c6bacce0b
+Create Date: 2025-06-11 18:12:33.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "854c7f4bb0c1"
+down_revision: Union[str, None] = "f26c6bacce0b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event",
+        sa.Column("id", sa.String(length=255), primary_key=True),
+        sa.Column("group_jid", sa.String(length=255), sa.ForeignKey("group.group_jid"), nullable=True),
+        sa.Column("message_id", sa.String(length=255), sa.ForeignKey("message.message_id"), nullable=True),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("location", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("event")

--- a/src/events/extract.py
+++ b/src/events/extract.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from pydantic_ai import Agent
+from pydantic_ai.agent import AgentRunResult
+
+from models.event import Event
+
+logger = logging.getLogger(__name__)
+
+
+async def parse_event(text: str) -> Optional[Event]:
+    """Parse event details from free text using an LLM.
+
+    Returns ``None`` when no event is detected.
+    """
+    if not text:
+        return None
+
+    agent = Agent(
+        model="anthropic:claude-4-sonnet-20250514",
+        system_prompt="""Extract meeting or event details from the following message.\n"
+        "If no event information is present return null.\n"
+        "Respond in JSON following the Event schema.""",
+        result_type=Event,
+        retries=3,
+    )
+
+    try:
+        result: AgentRunResult[Event] = await agent.run(text)
+        return result.data
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("parse_event failed: %s", exc)
+        return None

--- a/src/events/test_extract.py
+++ b/src/events/test_extract.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic_ai import Agent
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from events.extract import parse_event
+from models.event import Event
+
+
+@pytest.mark.asyncio
+async def test_parse_event_hebrew(monkeypatch):
+    text = "היי, ב-1 בינואר 2025 בשעה 10:00 נפגש בקפה ביאליק להרצאה על בינה מלאכותית עד 12:00"
+    expected = Event(
+        id="e1",
+        title="הרצאה על בינה מלאכותית",
+        start_time=datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+        end_time=datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc),
+        location="קפה ביאליק",
+    )
+
+    async def run(self, *_args, **_kwargs):
+        return SimpleNamespace(data=expected)
+
+    monkeypatch.setattr(Agent, "__init__", lambda self, *a, **k: None)
+    monkeypatch.setattr(Agent, "run", run)
+
+    event = await parse_event(text)
+    assert event == expected
+

--- a/src/handler/base_handler.py
+++ b/src/handler/base_handler.py
@@ -69,7 +69,20 @@ class BaseHandler:
                     await self.session.flush()
 
             # Finally add the message
-            return await self.upsert(message)
+            stored = await self.upsert(message)
+
+            from events.extract import parse_event
+
+            if stored.text:
+                event = await parse_event(stored.text)
+                if event:
+                    event.message_id = stored.message_id
+                    event.group_jid = stored.group_jid
+                    if not event.id:
+                        event.id = stored.message_id
+                    await self.upsert(event)
+
+            return stored
 
     async def send_message(
         self, to_jid: str, message: str, in_reply_to: str | None = None

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -4,6 +4,7 @@ from .message import Message, BaseMessage
 from .sender import Sender, BaseSender
 from .upsert import upsert, bulk_upsert
 from .webhook import WhatsAppWebhookPayload
+from .event import Event
 
 __all__ = [
     "Group",
@@ -17,4 +18,5 @@ __all__ = [
     "bulk_upsert",
     "KBTopic",
     "KBTopicCreate",
+    "Event",
 ]

--- a/src/models/event.py
+++ b/src/models/event.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlmodel import SQLModel, Field, Column, DateTime
+
+
+class Event(SQLModel, table=True):
+    id: str = Field(primary_key=True)
+    group_jid: Optional[str] = Field(
+        default=None, max_length=255, foreign_key="group.group_jid"
+    )
+    message_id: Optional[str] = Field(
+        default=None, max_length=255, foreign_key="message.message_id"
+    )
+    title: str
+    start_time: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+    end_time: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+    location: Optional[str] = Field(default=None, max_length=255)
+
+
+Event.model_rebuild()


### PR DESCRIPTION
## Summary
- add Event model
- parse events from message text with an LLM
- persist detected events when storing messages
- create migration for the events table
- test Hebrew event extraction

## Testing
- `ruff check src/events/extract.py src/models/event.py src/events/test_extract.py src/handler/base_handler.py src/models/__init__.py`
- `pyright src/events/extract.py src/models/event.py src/events/test_extract.py src/handler/base_handler.py src/models/__init__.py` *(fails: venv not found)*
- `pytest src/events/test_extract.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c65ce1388322a24e00e45eef8cff