### PR TITLE
Improve bot mention handling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,38 @@ docker-compose up -d
 
 4. Initialize the WhatsApp connection by scanning the QR code through the WhatsApp web interface.
 
+## Usage
+
+1. Mark a WhatsApp group as managed in the database using `UPDATE "group" SET managed = true WHERE group_jid = '<jid>';`.
+2. Mention the bot's phone number **and** include the word `bot` to activate it, for example:
+
+   ```text
+   @<bot-number> bot summarize
+   ```
+
+3. The bot can summarize the last 24 hours of chat or answer knowledge base questions when triggered.
+
+
 ## Developing
 
 * install uv tools `uv sync --all-extras --active`
 * run ruff (Python linter and code formatter) `ruff check` and `ruff format`
 * check for types usage `pyright`
+## Testing
+
+Install dev dependencies and run the test suite after starting the supporting services:
+```bash
+uv sync --all-extras --dev
+docker-compose up -d
+pytest
+```
+
+Tests require the environment variables described in the Setup section. To generate coverage reports use:
+```bash
+uv run coverage run --source=pytest_evals -m pytest
+uv run coverage xml
+```
+
 
 ## Architecture
 
@@ -72,4 +99,4 @@ The project consists of several key components:
 
 ## License
 
-[LICENCE](CODE_OF_CONDUCT.md)
+[LICENSE](LICENSE)

--- a/src/handler/__init__.py
+++ b/src/handler/__init__.py
@@ -40,8 +40,9 @@ class MessageHandler(BaseHandler):
         if message and message.group and not message.group.managed:
             return
         
-        if  message.has_mentioned(await self.whatsapp.get_my_jid()):
-                    await self.router(message)
+        bot_jid = await self.whatsapp.get_my_jid()
+        if message.has_mentioned(bot_jid) and "bot" in message.text.lower():
+            await self.router(message)
 
         # Handle whatsapp links in group 
         if "https://chat.whatsapp.com/" in message.text:

--- a/src/handler/base_handler.py
+++ b/src/handler/base_handler.py
@@ -43,8 +43,8 @@ class BaseHandler:
         if isinstance(message, BaseMessage):
             message = Message(**message.model_dump())
 
-        if not message.text:
-            return message  # Don't store messages without text
+        if not message.text and not message.media_url:
+            return message  # Don't store completely empty messages
 
         async with self.session.begin_nested():
             # Ensure sender exists and is committed

--- a/src/handler/test_base_handler.py
+++ b/src/handler/test_base_handler.py
@@ -1,0 +1,19 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from handler.base_handler import BaseHandler
+from models import Message, Sender
+from test_utils.mock_session import mock_session  # noqa
+
+
+@pytest.mark.asyncio
+async def test_store_message_with_media_only(mock_session):
+    handler = BaseHandler(mock_session, AsyncMock(), AsyncMock())
+    msg = Message(
+        message_id="media_only",
+        chat_jid="123@g.us",
+        sender_jid="u@s.whatsapp.net",
+        media_url="http://example.com/image.jpg",
+    )
+    await handler.store_message(msg)
+    mock_session.get.assert_any_call(Sender, msg.sender_jid)


### PR DESCRIPTION
## Summary
- allow storing media-only messages
- require mentioning the bot *and* the word `bot` before routing
- document how to use and test the project
- add a minimal test for storing media messages
- fix README license link

## Testing
- `pip install sqlmodel pydantic httpx voyageai pgvector pydantic_ai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477f18afa88322b1743536c457a0d6