### PR TITLE
Fix README license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ The project consists of several key components:
 
 ## License
 
-[LICENCE](CODE_OF_CONDUCT.md)
+[LICENSE](LICENSE)


### PR DESCRIPTION
## Summary
- correct the license reference in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c676f07c83229c9777dfb3d652dc