### PR TITLE
Add calendar export

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ The project consists of several key components:
 - Message handler: `src/handler/__init__.py`
 - Database models: `src/models/`
 
+## Calendar Export
+
+Events stored in the database can be exported to an iCalendar file. You can run
+the standalone script:
+
+```bash
+python -m app.calendar
+```
+
+This writes `calendar.ics` in the current directory. When the FastAPI server is
+running, the same content is available at `http://localhost:5001/calendar.ics`.
+
 ## Contributing
 
 1. Fork the repository

--- a/app/calendar.py
+++ b/app/calendar.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel.ext.asyncio.session import AsyncSession
+from ics import Calendar, Event as ICSEvent
+
+from config import Settings
+from models import Event
+
+
+async def write_calendar(session: AsyncSession, path: Path) -> None:
+    events = (await session.exec(Event.select())).all()  # type: ignore[arg-type]
+    cal = Calendar()
+
+    for event in events:
+        ics_event = ICSEvent()
+        ics_event.name = event.title
+        ics_event.begin = event.start_time
+        if event.end_time:
+            ics_event.end = event.end_time
+        if event.description:
+            ics_event.description = event.description
+        cal.events.add(ics_event)
+
+    path.write_text(cal.serialize())
+
+
+async def main() -> None:
+    settings = Settings()
+    engine = create_async_engine(settings.db_uri)
+    async_session = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+    async with async_session() as session:
+        await write_calendar(session, Path("calendar.ics"))
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "alembic>=1.14.1",
     "logfire[fastapi,httpx,sqlalchemy,system-metrics]>=3.12.0",
+    "ics>=0.7",
 ]
 
 [dependency-groups]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -4,6 +4,7 @@ from .message import Message, BaseMessage
 from .sender import Sender, BaseSender
 from .upsert import upsert, bulk_upsert
 from .webhook import WhatsAppWebhookPayload
+from .event import Event
 
 __all__ = [
     "Group",
@@ -17,4 +18,5 @@ __all__ = [
     "bulk_upsert",
     "KBTopic",
     "KBTopicCreate",
+    "Event",
 ]

--- a/src/models/event.py
+++ b/src/models/event.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlmodel import SQLModel, Field, Column, DateTime
+
+
+class BaseEvent(SQLModel):
+    id: str = Field(primary_key=True, max_length=255)
+    title: str
+    start_time: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    end_time: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True))
+    )
+    description: Optional[str] = None
+    group_jid: Optional[str] = Field(
+        default=None, foreign_key="group.group_jid", max_length=255
+    )
+
+
+class Event(BaseEvent, table=True):
+    pass
+
+
+Event.model_rebuild()


### PR DESCRIPTION
## Summary
- include `ics` as dependency
- define `Event` model
- add calendar route and standalone exporter
- document calendar usage in README

## Testing
- `ruff format app/main.py app/calendar.py src/models/event.py src/models/__init__.py`
- `ruff check app/main.py app/calendar.py src/models/event.py src/models/__init__.py`
- `pyright` *(fails: missing imports)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849c66154a88322ba21fa4b61513365