### PR TITLE
Add OCR utility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "alembic>=1.14.1",
     "logfire[fastapi,httpx,sqlalchemy,system-metrics]>=3.12.0",
+    "pytesseract>=0.3.13",
 ]
 
 [dependency-groups]

--- a/src/utils/ocr.py
+++ b/src/utils/ocr.py
@@ -1,0 +1,41 @@
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+import pytesseract
+from PIL import Image
+from whatsapp import WhatsAppClient
+import io
+
+
+async def _download_image(client: WhatsAppClient, path: str) -> bytes:
+    response = await client.client.get(path)
+    response.raise_for_status()
+    return response.content
+
+
+async def extract_text(media_path: str, lang: str = "heb") -> str:
+    """Extract text from an image using Tesseract.
+
+    If ``media_path`` does not point to a local file it will be fetched using
+    :class:`WhatsAppClient` before running OCR.
+    """
+    data: Optional[bytes] = None
+
+    file_path = Path(media_path)
+    if file_path.exists():
+        data = file_path.read_bytes()
+    else:
+        async with WhatsAppClient() as client:
+            # If the provided path is relative, prepend a slash so WhatsApp
+            # server treats it as absolute.
+            url = (
+                media_path
+                if media_path.startswith("http")
+                else f"/{media_path.lstrip('/')}"
+            )
+            data = await _download_image(client, url)
+
+    image = Image.open(io.BytesIO(data))
+    text = await asyncio.to_thread(pytesseract.image_to_string, image, lang=lang)
+    return text.strip()

--- a/src/utils/test_ocr.py
+++ b/src/utils/test_ocr.py
@@ -1,0 +1,17 @@
+import pytest
+from PIL import Image, ImageDraw, ImageFont
+from utils.ocr import extract_text
+
+
+@pytest.mark.asyncio
+async def test_extract_text(tmp_path):
+    # Create a small image with Hebrew text
+    img_path = tmp_path / "heb.png"
+    img = Image.new("RGB", (100, 50), "white")
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 24)
+    draw.text((5, 5), "שלום", fill="black", font=font)
+    img.save(img_path)
+
+    result = await extract_text(str(img_path))
+    assert "שלום" in result


### PR DESCRIPTION
## Summary
- add `pytesseract` to dependencies
- implement OCR helper for extracting text from images
- add async test for OCR using a generated Hebrew image

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849c65645ac83228fb2bb9c54af9db8