### PR TITLE
Add message table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To trigger a reply you must mention the bot's phone number **and** include the w
 * install uv tools `uv sync --all-extras --active`
 * run ruff (Python linter and code formatter) `ruff check` and `ruff format`
 * check for types usage `pyright`
+* create Alembic migrations on the host machine and commit them to the repo
 ## Testing
 
 Install dev dependencies and run the test suite after starting the supporting services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ./src:/app/src
       - ./src/.env:/app/.env
+      - ./migrations:/app/migrations
     ports:
       - "5001:5001"
     depends_on:

--- a/migrations/versions/525f47ea96e3_add_message_table.py
+++ b/migrations/versions/525f47ea96e3_add_message_table.py
@@ -1,0 +1,46 @@
+"""add message table
+
+Revision ID: 525f47ea96e3
+Revises: f26c6bacce0b
+Create Date: 2025-06-12 00:27:09.351610
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "525f47ea96e3"
+down_revision: Union[str, None] = "f26c6bacce0b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "message",
+        sa.Column("message_id", sa.String(length=255), primary_key=True),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("text", sa.Text(), nullable=True),
+        sa.Column("media_url", sa.String(length=255), nullable=True),
+        sa.Column("chat_jid", sa.String(length=255), nullable=False),
+        sa.Column(
+            "sender_jid",
+            sa.String(length=255),
+            sa.ForeignKey("sender.jid"),
+            nullable=False,
+        ),
+        sa.Column(
+            "group_jid",
+            sa.String(length=255),
+            sa.ForeignKey("group.group_jid"),
+            nullable=True,
+        ),
+        sa.Column("reply_to_id", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("message")

--- a/migrations/versions/854c7f4bb0c1_add_event_table.py
+++ b/migrations/versions/854c7f4bb0c1_add_event_table.py
@@ -1,7 +1,7 @@
 """add events table
 
 Revision ID: 854c7f4bb0c1
-Revises: f26c6bacce0b
+Revises: 525f47ea96e3
 Create Date: 2025-06-11 18:12:33.000000
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "854c7f4bb0c1"
-down_revision: Union[str, None] = "f26c6bacce0b"
+down_revision: Union[str, None] = "525f47ea96e3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- create `message` table migration
- update `event` migration to depend on `message` table
- persist migrations volume in `docker-compose.yml`
- note migrations must be generated on host in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1e9ff33c8322a0ce19287756cd56