### PR TITLE
Add `.env.example` and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,13 @@ A WhatsApp bot that can participate in group conversations, powered by AI. The b
 
 1. Clone the repository
 
-2. Create a `.env` file in the src directory with the following variables:
+2. Copy the example environment file and update it with your credentials:
 
-```env
-WHATSAPP_HOST=http://localhost:3000
-WHATSAPP_BASIC_AUTH_USER=admin
-WHATSAPP_BASIC_AUTH_PASSWORD=admin
-VOYAGE_API_KEY=your_voyage_api_key
-DB_URI=postgresql+asyncpg://user:password@localhost:5432/postgres
-LOG_LEVEL=INFO
-ANTHROPIC_API_KEY=your-key-here # You need to have a real anthropic key here, starts with sk-....
-LOGFIRE_TOKEN=your-key-here # You need to have a real logfire key here
+```bash
+cp src/.env.example src/.env
 ```
+
+The `src/.env.example` file lists all required variables.
 
 3. Start the services:
 ```bash

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,10 @@
+WHATSAPP_HOST=http://localhost:3000
+WHATSAPP_BASIC_AUTH_USER=admin
+WHATSAPP_BASIC_AUTH_PASSWORD=admin
+VOYAGE_API_KEY=
+DB_URI=postgresql+asyncpg://user:password@localhost:5432/postgres
+LOG_LEVEL=INFO
+ANTHROPIC_API_KEY=
+LOGFIRE_TOKEN=
+
+# Copy this file to .env and fill in the required secrets


### PR DESCRIPTION
## Summary
- add an example env file under `src/`
- point the setup instructions to use this example file

## Testing
- `ruff check` *(fails: F811 redefinition and other lint errors)*
- `pytest -q` *(fails: ModuleNotFoundError for missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_684a4c00f87483228955f9f5c5980f71