### PR TITLE
Handle incomplete event parsing

### DIFF
--- a/src/handler/base_handler.py
+++ b/src/handler/base_handler.py
@@ -1,3 +1,4 @@
+import logging
 from sqlmodel.ext.asyncio.session import AsyncSession
 from voyageai.client_async import AsyncClient
 
@@ -80,11 +81,14 @@ class BaseHandler:
             if stored.text:
                 event = await parse_event(stored.text)
                 if event:
+                    if not event.title or not event.id:
+                        logging.warning("parse_event returned incomplete event: %s", event)
                     event.message_id = stored.message_id
                     event.group_jid = stored.group_jid
                     if not event.id:
                         event.id = stored.message_id
-                    await self.upsert(event)
+                    if event.title and event.id:
+                        await self.upsert(event)
 
             return stored
 

--- a/src/handler/test_base_handler.py
+++ b/src/handler/test_base_handler.py
@@ -2,13 +2,15 @@ import pytest
 from unittest.mock import AsyncMock
 
 from handler.base_handler import BaseHandler
-from models import Message, Sender
+from models import Message, Sender, Event
+from datetime import datetime, timezone
 from test_utils.mock_session import mock_session  # noqa
 
 
 @pytest.mark.asyncio
 async def test_store_message_with_media_only(mock_session):
     handler = BaseHandler(mock_session, AsyncMock(), AsyncMock())
+    handler.upsert = AsyncMock(side_effect=lambda m: m)
     msg = Message(
         message_id="media_only",
         chat_jid="123@g.us",
@@ -17,3 +19,31 @@ async def test_store_message_with_media_only(mock_session):
     )
     await handler.store_message(msg)
     mock_session.get.assert_any_call(Sender, msg.sender_jid)
+
+
+@pytest.mark.asyncio
+async def test_store_message_skips_incomplete_event(mock_session, monkeypatch):
+    handler = BaseHandler(mock_session, AsyncMock(), AsyncMock())
+    msg = Message(
+        message_id="msg1",
+        chat_jid="123@g.us",
+        sender_jid="u@s.whatsapp.net",
+        text="event text",
+    )
+
+    incomplete_event = Event(
+        id="",
+        title="",
+        start_time=datetime.now(timezone.utc),
+    )
+
+    monkeypatch.setattr(
+        "events.extract.parse_event", AsyncMock(return_value=incomplete_event)
+    )
+    handler.upsert = AsyncMock(side_effect=lambda m: m)
+
+    await handler.store_message(msg)
+
+    assert not any(
+        isinstance(call.args[0], Event) for call in handler.upsert.call_args_list
+    )

--- a/src/handler/test_router.py
+++ b/src/handler/test_router.py
@@ -75,6 +75,7 @@ async def test_router_ask_question_route(
 
     # Create router instance
     router = Router(mock_session, mock_whatsapp, mock_embedding_client)
+    router.upsert = AsyncMock(side_effect=lambda m: m)
 
     # Test the route
     await router(test_message)
@@ -172,6 +173,7 @@ async def test_send_message(
     mock_session: AsyncSessionMock,
     mock_whatsapp: AsyncMock,
     mock_embedding_client: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     # Set up mock response
     mock_whatsapp.send_message.return_value.results.message_id = "response_id"
@@ -179,6 +181,8 @@ async def test_send_message(
 
     # Create router instance
     router = Router(mock_session, mock_whatsapp, mock_embedding_client)
+    router.upsert = AsyncMock(side_effect=lambda m: m)
+    monkeypatch.setattr("events.extract.parse_event", AsyncMock(return_value=None))
 
     # Test sending a message
     await router.send_message("user@s.whatsapp.net", "Test message")


### PR DESCRIPTION
## Summary
- warn and skip event insertion if parse_event returns incomplete data
- add coverage for skipping incomplete events
- fix tests to mock upsert calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afe57f0408322b545b9b0a7e354a9