### PR TITLE
Fix sunrise query parsing

### DIFF
--- a/src/bot/zmanim_handler.py
+++ b/src/bot/zmanim_handler.py
@@ -179,7 +179,7 @@ def get_hebrew_date_string(target_date: date) -> str:
 
 ZMAN_KEYWORDS = {
     "alot_hashachar": r"עלות",
-    "netz_hachama": r"הנץ",
+    "netz_hachama": r"הנץ|זריחה",
     "sof_zman_shema": r"שמע",
     "sof_zman_tefila": r"תפילה",
     "chatzot": r"חצות",

--- a/tests/test_zmanim_handler.py
+++ b/tests/test_zmanim_handler.py
@@ -12,9 +12,16 @@ from bot.zmanim_handler import (
 @pytest.mark.parametrize(
     "query,expected",
     [
-        ("מתי שקיעה?", {"type": "specific", "zman": "shkiat_hachama", "target": "today"}),
+        (
+            "מתי שקיעה?",
+            {"type": "specific", "zman": "shkiat_hachama", "target": "today"},
+        ),
         ("מה זמני היום", {"type": "all", "target": "today"}),
-        ("מחר עלות", {"type": "specific", "zman": "alot_hashachar", "target": "tomorrow"}),
+        (
+            "מחר עלות",
+            {"type": "specific", "zman": "alot_hashachar", "target": "tomorrow"},
+        ),
+        ("מתי זריחה?", {"type": "specific", "zman": "netz_hachama", "target": "today"}),
     ],
 )
 def test_parse_zmanim_query(query, expected):


### PR DESCRIPTION
## Summary
- recognize Hebrew 'זריחה' for sunrise
- test parsing for sunrise requests

## Testing
- `ruff check src/bot/zmanim_handler.py tests/test_zmanim_handler.py --quiet`
- `PYTHONPATH=src pytest tests/test_zmanim_handler.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684b23e364808322a1450ab322ee77b0